### PR TITLE
Fix previous URL in two-part forward transitions

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -97,13 +97,18 @@ function run(route, page, params, next, reroute, isTransitional) {
     , onRoute = callbacks.onRoute
 
   if (callbacks.forward) {
+    var intermediateUrl = mapRoute(callbacks.from, params)
     var render = page.render
     page.render = function() {
+      // Make sure that the forward half of the transitional route
+      // realizes that it is coming from this base URL, as opposed
+      // to the original URL that the navigation started with.
+      params.previous = intermediateUrl
       onRoute(callbacks.forward, page, params, next, true)
       page.render = render
       render.apply(page, arguments)
     }
-    return reroute(mapRoute(callbacks.from, params))
+    return reroute(intermediateUrl)
   }
   onRoute(callbacks.callback, page, params, next, isTransitional)
 }


### PR DESCRIPTION
I have a transitional route that checks the previous URL to make sure that no parameters changed unexpectedly.  (see https://groups.google.com/forum/?fromgroups=#!topic/derbyjs/xcrJZ8vu_fc)

The problem is that if this transitional route runs on the client as a two-part navigation (meaning that Derby first runs a different route to get the the transition's from state, then runs the transition's forward callback), it incorrectly reports the original previous URL to the transition route.

I fixed it to report the URL of the base route that it just ran.
