### PR TITLE
Skip missing values of optional parameters

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -20,9 +20,13 @@ function mapRoute(from, params) {
   url = params.url
   queryString = ~(i = url.indexOf('?')) ? url.slice(i) : ''
   i = 0
-  path = from.replace(/(?:(?:\:([^?\/:*]+))|\*)\??/g, function(match, key) {
-    if (key) return params[key]
-    return params[i++]
+  // If the route looks like /:a/:b?/:c/:d?
+  // and :b and :d are missing, return /a/c
+  // Thus, skip the / if the value is missing
+  path = from.replace(/\/(?:(?:\:([^?\/:*]+))|\*)(\?)?/g, function(match, key, optional) {
+    var value = key ? params[key] : params[i++]
+    if (optional && value === void 0) return ''
+    return '/' + value
   })
   return path + queryString
 }


### PR DESCRIPTION
If a transitional route's `from` URL has optional parameters, and those parameters are missing, the intermediary URL will be constructed incorrectly.

This commit fixes that.
