### PR TITLE
Fixed typo (missing code)

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -33,8 +33,8 @@ function cancelRender(url, options, e) {
   if (e || options.noNavigate) return
   // Otherwise, manually perform appropriate action
   if (options.form) {
-    form._forceSubmit = true
-    return form.submit()
+    options.form._forceSubmit = true
+    return options.form.submit()
   } else {
     return window.location = url
   }


### PR DESCRIPTION
before:

``` javascript
  if (options.form) {
    form._forceSubmit = true
```

now:

``` javascript
  if (options.form) {
    options.form._forceSubmit = true
```
