### PR TITLE
Fixed mounting Derby app to an Express app using route other then '/'

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -61,6 +61,15 @@ function setup(app, createPage, onRoute) {
         return app
       }
 
+      /*
+       * Mounting Derby app to an Express app using route other then '/'
+       * requires specification of an `app.mountPoint` so Derby application
+       * routes can be matched correctly on the client side.
+       *
+       * expressApp.use(derbyApp.mountPoint = '/derby-app', derbyApp.router())
+       */
+      pattern = (app.mountPoint || '') + pattern
+
       queue.push(new Route(method, pattern, callback))
       return app
     }


### PR DESCRIPTION
Without this fix routing will work only on server side, because request
would be handled by Express first before passing it to `tracks` router.

Client side routing will fail because `tracks` router will receive
prefixed URL for handling, e.g. it will receive '/derby-app/home' while
knowing only about '/home' route.
