### PR TITLE
Fix `page.params` override by `exit` method (which caused execution of an incorrect `enter` method)

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -152,11 +152,31 @@ RenderReq.prototype.onMatch = function(route, params, next, done) {
     this.e.preventDefault()
     this.e = null
   }
-  this.page.params = params
+
+  /*
+   * NOTE: about routing on client, where 'HTTP request' means `get`. `post`,
+   * `put` and `del` methods intercepted by `tracks`.
+   *
+   * When router executes `exit` method on a previous route, `page.params` is
+   * already set to parameters of a new 'HTTP request', and these parameters
+   * will be used to match `enter` method for a new route.
+   *
+   * In order to route `enter` method correctly, `page.params` should not be
+   * replaced with the parameters of an `exit` route, e.g. `params.url` should
+   * not be set to the URL of a previous route.
+   *
+   * Because `page.params` used in a 'HTTP request' route is expected to have
+   * parameters of an initial 'HTTP request', they should not be changed to
+   * parameters of an `enter` and `exit` routes.
+   */
+  if (params.method !== 'enter' && params.method !== 'exit') {
+    this.page.params = params
+  }
+
   return this.onRoute(
     route.callbacks
   , this.page
-  , this.page.params
+  , params
   , next
   , route.isTransitional
   , done


### PR DESCRIPTION
See in-code comment about why `page.params` should not be overwritten by `exit` method.
