### PR TITLE
Reset req.url and req._route_index before calling transitional routes callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -107,6 +107,13 @@ function setup(app, createPage, onRoute) {
 
         var page = req._tracksPage
         var params = pageParams(req)
+        var url = req.url
+        var routeIndex = req._route_index
+
+        function resetReq() {
+          req.url = url
+          req._route_index = routeIndex
+        }
 
         // Wrap the render function to run the forward callback
         // immediately before rendering
@@ -128,17 +135,17 @@ function setup(app, createPage, onRoute) {
           }
           page.params = params
           params.previous = req.url
+          resetReq()
           var isAsync = onRoute(callback, page, params, wrapNext, true, done)
           if (isAsync) return
           done()
         }
         // Reroute with the new URL and modified page
-        var url = req.url
         req.url = router.mapRoute(from, params)
         expressRouter._dispatch(req, res, function(err) {
           if (err) return next(err)
           // Try again
-          req.url = url
+          resetReq()
           page.render = render
           expressRouterTransitional._dispatch(req, res, next)
         })


### PR DESCRIPTION
There was an issue where transitional routes were not correctly passing control to the next matching transitional route. This was because req.url and req._route_index were being contaminated when calling the 'from' route first.
