### PR TITLE
don't capture click events

### DIFF
--- a/lib/History.js
+++ b/lib/History.js
@@ -232,7 +232,7 @@ function addListeners(history) {
     }
   }
 
-  document.addEventListener('click', onClick, true)
+  document.addEventListener('click', onClick, false)
   document.addEventListener('submit', onSubmit, false)
   window.addEventListener('popstate', onPopState, true)
 }


### PR DESCRIPTION
I think non-capturing would work better than capturing click events?

If I have something like this: `<a href="" on-click="doSomething($event)">....</a>` and in `doSomething` I prevent the default, it will be too late because the url is already changed (in History.js).

Also https://github.com/derbyjs/tracks/issues/19
