### PR TITLE
Upgrade qs to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   },
   "browser": "./lib/browser.js",
   "dependencies": {
-    "qs": "~0.6.5",
+    "debug": "~0.7.2",
     "methods": "0.0.1",
-    "debug": "~0.7.2"
+    "qs": "^6.0.2"
   },
   "devDependencies": {
     "mocha": ">=1",


### PR DESCRIPTION
Upgrading to latest version of qs, patching:

- https://nodesecurity.io/advisories/28
- https://nodesecurity.io/advisories/29

Patches only require qs >= 1.0, but, latest is greatest.

cc: @nateps 