### PR TITLE
Pass along errors and make RenderReq public in order to be able to easily change it according to ones needs

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -5,6 +5,7 @@ module.exports = {
   render: render
 , isTransitional: isTransitional
 , mapRoute: mapRoute
+, RenderReq: RenderReq
 }
 
 function isTransitional(pattern) {
@@ -86,7 +87,7 @@ RenderReq.prototype.routeTransitional = function(i, next) {
     // no op function, so that routes can expect it to be defined
     function done() {}
     this.onMatch(item.to, params, function(err) {
-      if (err) return req.cancel()
+      if (err) return req.cancel(err)
       req.routeTransitional(i, next)
     }, done)
     return
@@ -102,7 +103,7 @@ RenderReq.prototype.routeQueue = function(i, next) {
     var req = this
     var params = this.routeParams(route)
     this.onMatch(route, params, function(err) {
-      if (err) return req.cancel()
+      if (err) return req.cancel(err)
       req.routeQueue(i, next)
     })
     return


### PR DESCRIPTION
Useful if one wants to log client side routing errors (there's currently no simple catch-all kind of way)
