### PR TITLE
Include window.location.hash when changing history

### DIFF
--- a/lib/History.js
+++ b/lib/History.js
@@ -2,7 +2,7 @@ var qs = require('qs')
 var parseUrl = require('url').parse
 var resolveUrl = require('url').resolve
 var router = require('./router')
-var currentPath = window.location.pathname + window.location.search
+var currentPath = window.location.pathname + window.location.search + window.location.hash
 
 // Replace the initial state with the current URL immediately,
 // so that it will be rendered if the state is later popped
@@ -72,7 +72,7 @@ History.prototype._update = function(historyMethod, relativeUrl, render, state, 
   state.$render = true
   state.$method = options.method
   window.history[historyMethod](state, null, options.url)
-  currentPath = window.location.pathname + window.location.search
+  currentPath = window.location.pathname + window.location.search + window.location.hash
   if (render) router.render(this, options, e)
 }
 
@@ -97,7 +97,7 @@ function routePath(url) {
   return match &&
     match.protocol === window.location.protocol &&
     match.host === window.location.host &&
-    match.pathname + (match.search || '')
+    match.pathname + (match.search || '') + (match.hash || '')
 }
 
 function renderOptions(e, path) {
@@ -132,7 +132,7 @@ function renderOptions(e, path) {
   return {
     method: method
   , url: path
-  , previous: window.location.pathname + window.location.search
+  , previous: window.location.pathname + window.location.search + window.location.hash
   , body: body
   , form: form
   , link: e && e._tracksLink
@@ -201,7 +201,7 @@ function addListeners(history) {
 
     var previous = currentPath
     var state = e.state
-    currentPath = window.location.pathname + window.location.search
+    currentPath = window.location.pathname + window.location.search + window.location.hash
 
     var options = {
       previous: previous


### PR DESCRIPTION
The current implementation of `History` ignores the `.hash` component of urls in most cases.

This means that situations where a link is meant to open a page and scroll to a particular section are impossible to implement semantically as the receiving route is unable to get the `hash` from the link.

### Changes

* Include the parsed `url.hash` and `window.location.hash` in path strings as expected