### PR TITLE
Keep URL hash across page transition, and jump to named element if present

### DIFF
--- a/lib/History.js
+++ b/lib/History.js
@@ -71,9 +71,16 @@ History.prototype._update = function(historyMethod, relativeUrl, render, state, 
   var options = renderOptions(e, path)
   state.$render = true
   state.$method = options.method
-  window.history[historyMethod](state, null, options.url)
+  window.history[historyMethod](state, null, options.url + (url.hash || ''))
   currentPath = window.location.pathname + window.location.search
   if (render) router.render(this, options, e)
+  // Jump to named element on new page, to mimic browser behavior
+  if (url.hash) {
+    var hashElement = document.getElementById(url.hash.substring(1))
+    if (hashElement) {
+      hashElement.scrollIntoView()
+    }
+  }
 }
 
 History.prototype.page = function() {


### PR DESCRIPTION
This fixes a two-pronged issue causing links within the the same Derby app to not respect the link's URL hash.

* The hash now gets set in the new window URL during page transition, instead of getting dropped entirely.
* After page transition, the page now scrolls to the first element with an id matching the fragment, mimicking default browser behavior.
